### PR TITLE
Fix server ESLint config

### DIFF
--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -1,8 +1,8 @@
 {
     "env": {
-        "browser": true,
         "commonjs": true,
-        "es2021": true
+        "es2021": true,
+        "node": true
     },
     "extends": "airbnb-base",
     "overrides": [


### PR DESCRIPTION
I accidentally set it as running in a browser environment instead of in node. It shouldn't affect too much, but this PR fixes it.